### PR TITLE
fix(telemetry): disable next telemetry post install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript": "^3.8.3"
   },
   "scripts": {
+    "postinstall": "yarn next telemetry disable",
     "check": "yarn lint",
     "lint": "tsc && eslint --cache 'src/**/*.{ts,tsx,js}' --fix",
     "test": "yarn patch && echo \"skipping tests\"",


### PR DESCRIPTION
this should disable next telemetry post install.
re: https://github.com/dappforce/subsocial-web-app/issues/157
